### PR TITLE
Fix collapse widget bugs and add features for tree view

### DIFF
--- a/web_widget_text_collapse_html/static/src/js/collapse.js
+++ b/web_widget_text_collapse_html/static/src/js/collapse.js
@@ -8,6 +8,9 @@ odoo.define("web_widget_text_collapse_html.collapse",
     // core._lt tool for allows term translation into the module
     var _lt = core._lt;
 
+    var Listview = require('web.ListView');
+    var formats = require('web.formats');
+
     //created a new field that inherits from the odoo standard fields
     var TextCollapse = core.form_widget_registry.get("html");
 
@@ -68,6 +71,16 @@ odoo.define("web_widget_text_collapse_html.collapse",
 
     // save the widget
     core.form_widget_registry.add('text_collapse_html',
-      TextCollapse);
+      textCollapseHTML);
+
+      Listview.Column.include({
+
+         _format: function (row_data, options) {
+
+      return formats.format_value(row_data[this.id].value, this, options.value_if_empty);
+
+         }
+
+     });
 
   });

--- a/web_widget_text_collapse_html/static/src/js/collapse.js
+++ b/web_widget_text_collapse_html/static/src/js/collapse.js
@@ -11,10 +11,9 @@ odoo.define("web_widget_text_collapse_html.collapse",
     //created a new field that inherits from the odoo standard fields
     var TextCollapse = core.form_widget_registry.get("html");
 
-    TextCollapse.include({
+    var textCollapseHTML = TextCollapse.extend({
         //function for change state of the link
         a_click: function() {
-            console.log("a click");
             if(this.innerText == core._t("show")){
                 this.innerText = core._t("hide");
              }else{
@@ -50,14 +49,14 @@ odoo.define("web_widget_text_collapse_html.collapse",
                     .attr('id', 'a_collapse')
                     .attr('role', 'button')
                     .attr('data-toggle', 'collapse')
-                    .attr('data-parent', '#accordion')
-                    .attr('href', '#collapseOne')
+                    .attr('data-parent', '#'+ self.id_for_label)
+                    .attr('href', '#'+ self.id_for_label)
                     .attr('aria-expanded', 'true')
-                    .attr('aria-controls', 'collapseOne')
+                    .attr('aria-controls',  self.id_for_label)
                     .text(_lt("show"));
                 a.click(this.a_click);
                 this.$el.before( a );
-                this.$el.wrap( '<div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne"></div>' );
+                this.$el.wrap( '<div id="' + self.id_for_label + '" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne"></div>' );
             }
         },
 


### PR DESCRIPTION
Fix collapse when there are multiple html field on the same screen
text_collapse_html field is no longer default for all html field
html fields are now formatted in tree view